### PR TITLE
Add public/ folder to serve static cached files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ viirs.geojson
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+
+# keep public folder
+public/*
+!public/.gitkeep

--- a/index.js
+++ b/index.js
@@ -206,8 +206,23 @@ function getViirs () {
   });
 }
 
+// Combine VIIRS info and turn it into a single MultiPoint
+// GeoJSON entity to reduce data transmission.
 function processViirsJSON(viirs0_12, viirs12_24, viirs24_48) {
-  return _.concat(viirs0_12.features, viirs12_24.features, viirs24_48.features);
+  var viirs = _.concat(viirs0_12.features, viirs12_24.features, viirs24_48.features);
+  var mp = [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "MultiPoint",
+        "coordinates": []
+      }
+    }
+  ]
+  _.each(viirs, e => {
+    mp[0].geometry.coordinates.push(e.geometry.coordinates)
+  })
+  return mp
 }
 
 // Return current fire data; either fetch from cache, or

--- a/index.js
+++ b/index.js
@@ -458,7 +458,7 @@ function getFireTimeSeries () {
           // make the data ready for use in Plotly.
           fireTimeSeries = formatData(fixedData);
           cache.set('fireTimeSeries', fireTimeSeries);
-          writePersistentCache(fireTimeSeries, 'tally.geojson')
+          writePersistentCache(fireTimeSeries, 'tally.json')
           resolve(fireTimeSeries);
         });
       }).catch(function(err) {

--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ app.get('/', function (req, res) {
     });
 });
 
-app.get('/fire-time-series', function (req, res) {
+app.get('/tally', function (req, res) {
   getFireTimeSeries()
     // After fetching the merged data from cache or
     // an upstream fetch, it's available as fireGeoJSON

--- a/index.js
+++ b/index.js
@@ -38,7 +38,10 @@ const cache = new NodeCache({ stdTTL: memoryCacheTimeout, checkperiod: memoryCac
 const fireFileCacheName = 'fires.geojson';
 const viirsFileCacheName = 'viirs.geojson';
 
+const PUBLIC_ROOT = 'public'
+
 var app = express();
+app.use(express.static(PUBLIC_ROOT))
 
 // https://stackoverflow.com/questions/2901102/how-to-print-a-number-with-commas-as-thousands-separators-in-javascript
 const numberWithCommas = (x) => {
@@ -264,7 +267,7 @@ function getFireGeoJSON () {
 // Write the Fire points/perims to a disk cache,
 // which will be the last resort if the upstream isn't available.
 var writePersistentCache = function (currentGeoJSON, fileCacheName) {
-  fs.writeFileSync(fileCacheName, JSON.stringify(currentGeoJSON));
+  fs.writeFileSync(PUBLIC_ROOT + '/' + fileCacheName, JSON.stringify(currentGeoJSON));
 }
 
 function getFireTimeSeries () {
@@ -455,6 +458,7 @@ function getFireTimeSeries () {
           // make the data ready for use in Plotly.
           fireTimeSeries = formatData(fixedData);
           cache.set('fireTimeSeries', fireTimeSeries);
+          writePersistentCache(fireTimeSeries, 'tally.geojson')
           resolve(fireTimeSeries);
         });
       }).catch(function(err) {

--- a/index.js
+++ b/index.js
@@ -186,7 +186,11 @@ function getViirs () {
           // Each element in the `results` is a two-element array,
           // first element is the data; 2nd is the URL.
           viirsGeoJSON = processViirsJSON(results[0][0], results[1][0], results[2][0]);
-          writePersistentCache(viirsGeoJSON, viirsFileCacheName);
+          writePersistentCache({
+            type: 'FeatureCollection',
+            features: viirsGeoJSON,
+            source: 'memory cache'
+          }, viirsFileCacheName);
           cache.set('viirsGeoJSON', viirsGeoJSON);
           resolve(viirsGeoJSON);
         }
@@ -248,7 +252,11 @@ function getFireGeoJSON () {
           // Each element in the `results` is a two-element array,
           // first element is the data; 2nd is the URL.
           fireGeoJSON = processGeoJSON(results[0][0], results[1][0], results[2][0], results[3][0]);
-          writePersistentCache(fireGeoJSON, fireFileCacheName);
+          writePersistentCache({
+            type: 'FeatureCollection',
+            features: fireGeoJSON,
+            source: 'memory cache'
+          }, fireFileCacheName);
           cache.set('fireGeoJSON', fireGeoJSON);
           resolve(fireGeoJSON);
         }


### PR DESCRIPTION
This allows applications to simply request the cached json/geojson data directly, reducing the chance of trouble with hiccups while the cache is regenerated.

Also, this changes how VIIRS data is pre-processed to reduce the size.  It's done as a single MultiPoint feature now, which cuts back the size pretty significantly.

Test instance of this branch is online here:  http://test.xye5qhqyxm.us-west-2.elasticbeanstalk.com

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ua-snap/mv-aicc-fire-shim/31)
<!-- Reviewable:end -->